### PR TITLE
dev/ioctl_interface: fix build error on linux 4.18

### DIFF
--- a/dev/ioctl_interface.c
+++ b/dev/ioctl_interface.c
@@ -12,6 +12,7 @@
 #include <asm/uaccess.h>
 #include <linux/delay.h>
 #include <linux/cdev.h>	
+#include <linux/uaccess.h>
 
 #include "ioctl_dev.h"
 #include "ioctl.h"


### PR DESCRIPTION
dev/ioctl_interface.c:144:8: error: implicit declaration of function 'copy_to_user'; did you mean 'raw_copy_to_user'? [-Werror=implicit-function-declaration]
    if (copy_to_user((uint32_t*) arg, &value, sizeof(value))){
        ^~~~~~~~~~~~
        raw_copy_to_user

Signed-off-by: zhoumin <zhoumin@loongson.cn>